### PR TITLE
Unbreak xscreensaver-settings

### DIFF
--- a/Qubes-0002-Remove-Documentation-link-since-we-are-offline.patch
+++ b/Qubes-0002-Remove-Documentation-link-since-we-are-offline.patch
@@ -3,7 +3,7 @@ From: unman <unman@thirdeyesecurity.org>
 Date: Sun, 28 Feb 2021 14:26:19 +0000
 Subject: [PATCH] Remove Documentation link (since we are offline).
 
-emove ref to jwz in help
+Remove ref to jwz in help
 ---
  driver/demo-Gtk.c           | 2 +-
  driver/xscreensaver-demo.ui | 7 -------
@@ -37,6 +37,26 @@ index a6e4e2e..85aa6e6 100644
                        </object>
                        <packing>
                          <property name="padding">0</property>
+diff --git a/driver/demo.ui b/driver/demo.ui
+index 8860c9d3..d2d30ab5 100644
+--- a/driver/demo.ui
++++ b/driver/demo.ui
+@@ -283,15 +283,6 @@
+                             <signal handler="about_menu_cb" name="activate"/>
+                           </object>
+                         </child>
+-                        <child>
+-                          <object class="GtkImageMenuItem">
+-                            <property name="label" translatable="yes">Documentation...</property>
+-                            <property name="visible">True</property>
+-                            <property name="can-focus">False</property>
+-                            <property name="use-underline">True</property>
+-                            <signal handler="doc_menu_cb" name="activate"/>
+-                          </object>
+-                        </child>
+                       </object>
+                     </child>
+                   </object>
 diff --git a/driver/xscreensaver-command.c b/driver/xscreensaver-command.c
 index 0dab564..37e14c8 100644
 --- a/driver/xscreensaver-command.c
@@ -50,3 +70,23 @@ index 0dab564..37e14c8 100644
  \n";
  
  #define USAGE(A,B) do { \
+diff --git a/driver/demo-Gtk.c b/driver/demo-Gtk.c
+index a84b4207..20fd13fe 100644
+--- a/driver/demo-Gtk.c
++++ b/driver/demo-Gtk.c
+@@ -236,7 +236,6 @@ G_DEFINE_TYPE (XScreenSaverApp, xscreensaver_app, GTK_TYPE_APPLICATION)
+   W(adv_button)			\
+   W(std_button)			\
+   W(cmd_label)			\
+-  W(manual)			\
+   W(visual)			\
+   W(visual_combo)		\
+   W(reset_button)		\
+@@ -4642,7 +4641,6 @@ sensitize_demo_widgets (state *s, Bool sensitive_p)
+     {
+       gtk_widget_set_sensitive (dialog->cmd_label, sensitive_p);
+       gtk_widget_set_sensitive (dialog->cmd_text, sensitive_p);
+-      gtk_widget_set_sensitive (dialog->manual, sensitive_p);
+       gtk_widget_set_sensitive (dialog->visual, sensitive_p);
+       gtk_widget_set_sensitive (dialog->visual_combo, sensitive_p);
+     }

--- a/xscreensaver-6.06-0001-switch_page_cb-backport-debian-1031076-for-DPMS-settings.patch
+++ b/xscreensaver-6.06-0001-switch_page_cb-backport-debian-1031076-for-DPMS-settings.patch
@@ -1,0 +1,27 @@
+From a29509f696227073ecf6a6c74a7b5c45bc21880c Mon Sep 17 00:00:00 2001
+From: XScreenSaver owners <xscreensaver-owner@fedoraproject.org>
+Date: Wed, 15 Feb 2023 17:25:16 +0900
+Subject: [PATCH] switch_page_cb: backport debian fix for DPMS settings issue
+
+Backport: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1031076
+Fix the issue that dpms enabled_p option is not preserved
+correctly.
+---
+ driver/demo-Gtk.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/driver/demo-Gtk.c b/driver/demo-Gtk.c
+index a84b420..baacf31 100644
+--- a/driver/demo-Gtk.c
++++ b/driver/demo-Gtk.c
+@@ -1677,6 +1677,7 @@ switch_page_cb (GtkNotebook *notebook, GtkWidget *page,
+   state *s = &win->state;
+ 
+   if (s->debug_p) fprintf (stderr, "%s: tab changed\n", blurb());
++  populate_prefs_page (s);
+   pref_changed_cb (GTK_WIDGET (notebook), user_data);
+ 
+   /* If we're switching to page 0, schedule the current hack to be run.
+-- 
+2.39.2
+

--- a/xscreensaver-6.06-0002-distort_reset-restrict-radius-by-xgwa-correctly.patch
+++ b/xscreensaver-6.06-0002-distort_reset-restrict-radius-by-xgwa-correctly.patch
@@ -1,0 +1,41 @@
+From 8299606b2c4b707ef759eb97a7cd5e1e38d2f186 Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Thu, 2 Mar 2023 21:44:14 +0900
+Subject: [PATCH] distort_reset: restrict radius by xgwa correctly
+
+new_rnd_coo() sets st->xy_coo[k].x and y, which calculates
+the reminder of division, and this requires
+both `st->xgwa.width-2*st->radius` and `st->xgwa.height-2*st->radius`
+must be positive.
+
+Otherwise, st->xy_coo[k].x or y can be negative, then plain_draw() passes
+negative value to x or y for st->draw_routine(), then in st->draw_rountine()
+(actually this is fast_draw_32() or so) segfault can happen.
+
+So restrict st->radius value correctly so that st->radius is
+smaller than min { st->xgwa.height, st->xgwa.width } / 2.
+
+- fix ternary operator result so that lesser value is chosen
+- avoid zero division - if st->radius is exactly the half of the chosen value
+  above, st->xgwa.width-2*st->radius (or height side) gets 0, which causes
+  zero division, so choose lesser value than 1/2 - now chose 2/5.
+---
+ hacks/distort.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hacks/distort.c b/hacks/distort.c
+index fd605f6..2795119 100644
+--- a/hacks/distort.c
++++ b/hacks/distort.c
+@@ -243,7 +243,7 @@ distort_reset (struct state *st)
+      */
+     {
+       int max = (st->xgwa.width > st->xgwa.height
+-                 ? st->xgwa.width : st->xgwa.height) / (2 * st->number);
++                 ? st->xgwa.height : st->xgwa.width) * 2 / (5 * st->number);
+       if (st->radius > max) st->radius = max;
+     }
+ 
+-- 
+2.39.2
+

--- a/xscreensaver.spec.in
+++ b/xscreensaver.spec.in
@@ -850,6 +850,7 @@ list_files() {
                -e "s@/[a-z][a-z]*/\.\./@/@"                    \
       | sed    -e 's@\(.*/man/.*\)@%%doc \1\*@'                      \
                -e 's@\(.*/pam\.d/\)@%%config(noreplace) \1@'    \
+               -e 's@\(.*/xscreensaver-auth\)@%%attr(4755,root,root) \1@'    \
       | sort  \
       | uniq
 }

--- a/xscreensaver.spec.in
+++ b/xscreensaver.spec.in
@@ -115,6 +115,10 @@ Patch10:          Qubes-0009-Update-to-4-2-branding.patch
 Patch21:         xscreensaver-6.06-webcollage-default-nonet.patch
 # misc: kill gcc warn_unused_result warnings
 Patch3607:       xscreensaver-5.36-0007-misc-kill-gcc-warn_unused_result-warnings.patch
+# switch_page_cb: backport debian fix for DPMS settings issue (debian bug 1031076)
+Patch4601:       xscreensaver-6.06-0001-switch_page_cb-backport-debian-1031076-for-DPMS-settings.patch
+# distort_reset: restrict radius by xgwa correctly (bug 2174626)
+Patch4602:       xscreensaver-6.06-0002-distort_reset-restrict-radius-by-xgwa-correctly.patch
 # Fedora specific
 # window_init: search parenthesis first for searching year
 Patch10001:     xscreensaver-6.00-0001-screensaver_id-search-parenthesis-first-for-searchin.patch
@@ -408,6 +412,8 @@ find . -name \*.c -exec chmod ugo-x {} \;
 %__cat %PATCH21 | %__git am
 
 #%%__cat %PATCH3607 | %__git am
+%__cat %PATCH4601 | %__git am
+%__cat %PATCH4602 | %__git am
 %__cat %PATCH10001 | %__git am
 
 %__cat %PATCH14001 | %__git am


### PR DESCRIPTION
The patch removing online links was buggy and missed few places. This 
resulted in xscreensaver-settings not starting at all (complaining about 
missing 'manual' GTK object). Fix the patch to remove remaining references
too.

While at it, include other fixes too.

Fixes QubesOS/qubes-issues#8266